### PR TITLE
Include the required pager duty API key in an auth header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,61 @@
 # pagerduty-trigger
-`npm install pagerduty-trigger`.<br>
+
+`npm install pagerduty-trigger`
+
 A small module that allows you to [trigger](https://developer.pagerduty.com/documentation/integration/events/trigger) a [PagerDuty](https://www.pagerduty.com/) alert and returns an `incident key`.
 
-You must set a service key environment variable called `PAGER_DUTY_SERVICE`.  
+## Usage
 
-#### Usage
-    var triggerAlert = require("pagerduty-trigger");
-#### Examples
-Set environment variable for your pager duty service key:
+Set two environment variables:
 
-    process.env.PAGER_DUTY_SERVICE = 'Your service key here';
+```bash
+export PAGER_DUTY_SERVICE=your-service-id
+export PAGER_DUTY_API_KEY=an-api-key-with-write-perms
+```
+
+You can then trigger an alert like this:
+
+```js
+var triggerAlert = require('pagerduty-trigger');
+triggerAlert('One of the flayrods has gone out of skew on treadle!', function(err, incidentID) {
+    console.log('incident created with id ' + incidentID);
+});
+```
+
+## API
 
 `pagerduty-trigger` takes a string as the first argument, representing the description.
 
-    triggerAlert("Your description!", function(err, incident_key) {
-    //your code here
-    });
+```js
+  triggerAlert("Your description!", function(err, incident_key) {
+  //your code here
+  });
+```
 
 `pagerduty-trigger` can also take an object as the first argument.
 
-    var event = {
-       "description": "Your description",
-       "contexts":[
-        {
-          "type": "link",
-          "href": "http://acme.pagerduty.com"
-        }],
-        "details": {
-          "ping time": "1500ms",
-          "load avg": 0.75
-        }
-    };
-    triggerAlert(event, function(err, incident_key) {
-      //your code here
-    });
+```js
+var event = {
+   "description": "Your description",
+   "contexts":[
+    {
+      "type": "link",
+      "href": "http://acme.pagerduty.com"
+    }],
+    "details": {
+      "ping time": "1500ms",
+      "load avg": 0.75
+    }
+};
+triggerAlert(event, function(err, incident_key) {
+  //your code here
+});
+```
+
+## command-line tool
+
+You can create an event using the handy command-line tool `pd-trigger`. Usage:
+
+`pd-trigger "One of the flayrods has gone out of skew on treadle!"`
+
+It will respond with the ID of the incident created.

--- a/main.js
+++ b/main.js
@@ -2,49 +2,52 @@ var os = require('os');
 var request = require('request');
 
 function triggerAlert(event, callback) {
-  if (!process.env.PAGER_DUTY_SERVICE) {
-    callback(new Error("environment variable PAGER_DUTY_SERVICE not defined"));
-    return;
-  }
+    if (!process.env.PAGER_DUTY_SERVICE)
+        return callback(new Error('environment variable PAGER_DUTY_SERVICE not defined'));
 
-  var payload = {
-    'event_type': 'trigger',
-    'client': os.hostname(),
-    'service_key': process.env.PAGER_DUTY_SERVICE
-  };
+    if (!process.env.PAGER_DUTY_API_KEY)
+        return callback(new Error('environment variable PAGER_DUTY_API_KEY not defined'));
 
-  if (typeof event === 'string') {
-    payload.description = event;
-  } else if (typeof event === 'object') {
-    payload.description = event.description;
-    if (event.context && Array.isArray(event.context)) {
-      payload.context = event.context;
+    var payload = {
+        event_type: 'trigger',
+        client: os.hostname(),
+        service_key: process.env.PAGER_DUTY_SERVICE
+    };
+
+    if (typeof event === 'string') {
+        payload.description = event;
     }
-    if (event.details && event.details === 'object') {
-      payload.details = event.details;
+    else if (typeof event === 'object') {
+
+        payload.description = event.description;
+        if (event.context && Array.isArray(event.context))
+            payload.context = event.context;
+
+        if (event.details && event.details === 'object')
+            payload.details = event.details;
     }
-  }
-  //make sure the payload has a description field and that description is a string
-  if (!payload.description || typeof payload.description !== 'string') {
-    callback(new Error("Your alert needs a description"));
-    return;
-  }
-
-
-  var options = {
-    uri: 'https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-    method: 'POST',
-    json: payload
-  };
-
-
-  request(options, function(err, response, body) {
-    if(err) {return callback(err);}
-    if(response.statusCode >= 400){
-      return callback(new Error ("Unexpected status code " + response.statusCode ));
+    //make sure the payload has a description field and that description is a string
+    if (!payload.description || typeof payload.description !== 'string') {
+        return callback(new Error('Your alert needs a description'));
     }
-    callback(err, response.body.incident_key);
-  });
+
+    if (!payload.details)
+        payload.details = { description: payload.description };
+
+    var options = {
+        uri:     'https://events.pagerduty.com/generic/2010-04-15/create_event.json',
+        method:  'POST',
+        json:    payload,
+        headers: { Authorization: 'Token token=' + process.env.PAGER_DUTY_API_KEY }
+    };
+
+    request(options, function (err, response, body)
+    {
+        if (err) return callback(err);
+        if (response.statusCode >= 400)
+            return callback(new Error('Unexpected status code ' + response.statusCode));
+        callback(err, response.body.incident_key);
+    });
 }
 
 //node convention: check to see if something's wrong at the beginning, and if you don't have the required info then bail with error

--- a/package.json
+++ b/package.json
@@ -1,23 +1,34 @@
 {
   "name": "pagerduty-trigger",
-  "version": "1.0.0",
   "description": "trigger a pagerduty alert",
-  "main": "main.js",
-  "scripts": {
-    "test": "mocha -R spec test.js"
-  },
-  "repository": {
-    "type": "git",
-    "url" : "https://github.com/snopeks/pagerduty-trigger.git"
-    },
+  "version": "1.0.0",
   "author": "Stephanie Snopek",
-  "email" : "stephanie@npmjs.com",
-  "license": "ISC",
+  "bin": {
+    "pd-trigger": "trigger.js"
+  },
+  "bugs": {
+    "url": "https://github.com/snopeks/pagerduty-trigger/issues"
+  },
+  "dependencies": {
+    "chalk": "~1.1.1",
+    "request": "^2.65.0"
+  },
   "devDependencies": {
     "mocha": "^2.3.3",
     "must": "^0.13.1"
   },
-  "dependencies": {
-    "request": "^2.65.0"
+  "email": "stephanie@npmjs.com",
+  "homepage": "https://github.com/snopeks/pagerduty-trigger#readme",
+  "keywords": [
+    "pagerduty"
+  ],
+  "license": "ISC",
+  "main": "main.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/snopeks/pagerduty-trigger.git"
+  },
+  "scripts": {
+    "test": "mocha -R spec test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,9 +1,10 @@
-var demand = require("must");
-var triggerAlert = require("./main");
+/*global describe:true, it:true, before:true, after:true, beforeEach: true, afterEach:true */
 
-describe("alertbot", function() {
-  console.log(process.env.PAGER_DUTY_SERVICE);
-  it("returns an error if it doesn't have it's environment variable", function(done) {
+var demand = require('must');
+var triggerAlert = require('./main');
+
+describe('alertbot', function() {
+  it('returns an error if it doesn\'t have its environment variable', function(done) {
     var saved = process.env.PAGER_DUTY_SERVICE;
     delete process.env.PAGER_DUTY_SERVICE;
 
@@ -13,10 +14,21 @@ describe("alertbot", function() {
       process.env.PAGER_DUTY_SERVICE = saved;
       done();
     });
-
   });
 
-  it("returns an error if it doesn't get a description", function(done) {
+  it('returns an error if it doesn\'t have a pager duty API key', function(done) {
+    var saved = process.env.PAGER_DUTY_API_KEY;
+    delete process.env.PAGER_DUTY_API_KEY;
+
+    triggerAlert({}, function(err) {
+      err.must.be.an.object();
+      err.must.match(/environment variable PAGER_DUTY_API_KEY/);
+      process.env.PAGER_DUTY_API_KEY = saved;
+      done();
+    });
+  });
+
+  it('returns an error if it doesn\'t get a description', function(done) {
     triggerAlert({}, function(err) {
       err.must.be.an.object();
       err.must.match(/description/);
@@ -24,7 +36,7 @@ describe("alertbot", function() {
     });
   });
 
-  it("returns an error if description isn't string", function(done) {
+  it('returns an error if description isn\'t string', function(done) {
     triggerAlert(4, function(err) {
       err.must.be.a.object();
       err.must.match(/description/);
@@ -32,28 +44,30 @@ describe("alertbot", function() {
     });
   });
 
-  it("successfully triggers pagerduty with string description", function(done) {
+  it('successfully triggers pagerduty with string description', function(done) {
     process.env.PAGER_DUTY_SERVICE = 'e93facc04764012d7bfb002500d5d1a6';
-    triggerAlert("This is a test!", function(err, incident_key) {
+    triggerAlert('This is a test!', function(err, incident_key) {
       incident_key.must.be.a.string();
       done();
     });
   });
-  it("successfully triggers pagerduty with event object", function(done) {
+
+  it('successfully triggers pagerduty with event object', function(done) {
     process.env.PAGER_DUTY_SERVICE = 'e93facc04764012d7bfb002500d5d1a6';
     var event = {
-       "description": "Testing event object",
-       "contexts":[
+       'description': 'Testing event object',
+       'contexts':[
         {
-          "type": "link",
-          "href": "http://acme.pagerduty.com"
+          'type': 'link',
+          'href': 'http://acme.pagerduty.com'
         }],
-        "details": {
-          "ping time": "1500ms",
-          "load avg": 0.75
+        'details': {
+          'ping time': '1500ms',
+          'load avg': 0.75
         }
     };
     triggerAlert(event, function(err, incident_key) {
+      demand(err).not.exist();
       incident_key.must.be.a.string();
       done();
     });

--- a/trigger.js
+++ b/trigger.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+var trigger = require('./main'),
+	chalk   = require('chalk');
+
+if (process.argv.length < 3) {
+	console.error(chalk.red('USAGE: ./trigger.js "your alert text here"'));
+	process.exit(1);
+}
+
+var message = process.argv[2];
+trigger(message, function(err, id) {
+
+	if (err) {
+		console.error(chalk.red(err.message));
+		process.exit(1);
+	}
+
+	console.log('Incident created: ' + chalk.blue(id));
+});


### PR DESCRIPTION
We throw if the API key isn't present.  Added a test for this.

Wrote a handy command-line tool for creating an incident. Documented
the tool.
