### PR TITLE
Change Usage wording in trigger.js

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -4,7 +4,7 @@ var trigger = require('./main'),
 	chalk   = require('chalk');
 
 if (process.argv.length < 3) {
-	console.error(chalk.red('USAGE: ./trigger.js "your alert text here"'));
+	console.error(chalk.red('USAGE: pd-trigger "your alert text here"'));
 	process.exit(1);
 }
 


### PR DESCRIPTION
I updated the `Usage` wording in your trigger.js from `.\trigger.js` to `pd-trigger`.
You don't have to call the JS file by name since you've defined/aliased it in `package.json` as:

```
"bin": {
    "pd-trigger": "trigger.js"
  }
```

If you `npm install pagerduty-trigger`, then `pd-trigger` command works out of the box.
If you are trying to test `pd-trigger` command in your dev environment, you need to run `npm link` and NPM will take care of symbolic linking `pd-trigger` so you can use the command from anywhere your system without specifiying the full path to `trigger.js`.

Hope this helps.
